### PR TITLE
bug in named template attribute-string

### DIFF
--- a/lib/xslt/jatskit-html.xsl
+++ b/lib/xslt/jatskit-html.xsl
@@ -152,7 +152,7 @@
   
   <xsl:template name="attribute-string">
     <!-- Tests true if any attribute has a value not whitespace. -->
-    <xsl:if test="@*/matches(.,'\S')">
+    <xsl:if test="@*[matches(.,'\S']">
       <xsl:text> [</xsl:text>
       <xsl:for-each select="@*[matches(.,'\S')]">
         <xsl:if test="position() gt 1">; </xsl:if>

--- a/lib/xslt/jatskit-html.xsl
+++ b/lib/xslt/jatskit-html.xsl
@@ -152,7 +152,7 @@
   
   <xsl:template name="attribute-string">
     <!-- Tests true if any attribute has a value not whitespace. -->
-    <xsl:if test="@*[matches(.,'\S']">
+    <xsl:if test="@*[matches(.,'\S')]">
       <xsl:text> [</xsl:text>
       <xsl:for-each select="@*[matches(.,'\S')]">
         <xsl:if test="position() gt 1">; </xsl:if>


### PR DESCRIPTION
 with boolean check on a sequence of booleans
Maybe 
Oxygen output.
Description
FORG0006: Effective boolean value is not defined for a sequence of two or more items starting with a boolean
Severity
Error
System ID
O:\git\JATSKit_FOP\lib\xslt\jatskit-html.xsl
Start location
line: 155, column: 0
Additional info
http://www.w3.org/TR/2005/WD-xpath-functions-20050211/#ERRFORG0006